### PR TITLE
feat: add CLI toolbelt definitions for mem8 doctor

### DIFF
--- a/mem8-templates.yaml
+++ b/mem8-templates.yaml
@@ -55,3 +55,99 @@ templates:
       github_org: "your-org"
       github_repo: "thoughts"
       include_sync_scripts: true
+
+# Recommended CLI toolbelt for AI/automation workflows
+# mem8 doctor will check for these tools and provide installation guidance
+toolbelt:
+  # Core tools (strongly recommended)
+  required:
+    - name: "ripgrep"
+      command: "rg"
+      description: "Fast recursive search (better than grep)"
+      install:
+        windows: "winget install BurntSushi.ripgrep.MSVC"
+        macos: "brew install ripgrep"
+        linux: "apt install ripgrep"
+
+    - name: "fd"
+      command: "fd"
+      description: "Fast file finder (better than find)"
+      install:
+        windows: "winget install sharkdp.fd"
+        macos: "brew install fd"
+        linux: "apt install fd-find"
+
+    - name: "jq"
+      command: "jq"
+      description: "JSON processor"
+      install:
+        windows: "winget install jqlang.jq"
+        macos: "brew install jq"
+        linux: "apt install jq"
+
+    - name: "gh"
+      command: "gh"
+      description: "GitHub CLI"
+      version: ">=2.60"
+      install:
+        windows: "winget install GitHub.cli"
+        macos: "brew install gh"
+        linux: "apt install gh"
+
+    - name: "git"
+      command: "git"
+      description: "Version control"
+      install:
+        windows: "winget install Git.Git"
+        macos: "brew install git"
+        linux: "apt install git"
+
+  # Optional tools (nice to have)
+  optional:
+    - name: "bat"
+      command: "bat"
+      description: "Better cat with syntax highlighting"
+      install:
+        windows: "winget install sharkdp.bat"
+        macos: "brew install bat"
+        linux: "apt install bat"
+
+    - name: "delta"
+      command: "delta"
+      description: "Better git diff viewer"
+      install:
+        windows: "winget install dandavison.delta"
+        macos: "brew install git-delta"
+        linux: "apt install git-delta"
+
+    - name: "yq"
+      command: "yq"
+      description: "YAML/XML processor"
+      install:
+        windows: "winget install mikefarah.yq"
+        macos: "brew install yq"
+        linux: "apt install yq"
+
+    - name: "fzf"
+      command: "fzf"
+      description: "Fuzzy finder"
+      install:
+        windows: "winget install junegunn.fzf"
+        macos: "brew install fzf"
+        linux: "apt install fzf"
+
+    - name: "sd"
+      command: "sd"
+      description: "Simpler sed alternative"
+      install:
+        windows: "scoop install sd"
+        macos: "brew install sd"
+        linux: "cargo install sd"
+
+    - name: "ast-grep"
+      command: "ast-grep"
+      description: "AST-based code search"
+      install:
+        windows: "cargo install ast-grep"
+        macos: "brew install ast-grep"
+        linux: "cargo install ast-grep"


### PR DESCRIPTION
Add comprehensive toolbelt section to manifest with required and optional tools.

Required tools: ripgrep, fd, jq, gh (>=2.60), git
Optional tools: bat, delta, yq, fzf, sd, ast-grep

This enables projects to reference killerapp/mem8-templates directly without needing the #subdir syntax:

  mem8 doctor --template-source "killerapp/mem8-templates"

Or in .mem8/config.yaml:
  templates:
    default_source: killerapp/mem8-templates