### PR TITLE
fix(hooks): load cleanly on current Claude Code (SessionStart + drop duplicate manifest ref)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "development",
     "automation",
     "claude-code"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,15 +1,19 @@
 {
   "hooks": {
-    "PostInstall": [
+    "SessionStart": [
       {
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup-memory.sh",
-        "description": "Initialize memory directory structure"
-      },
-      {
-        "type": "command",
-        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/create-plugin-marker.sh",
-        "description": "Create plugin installation marker"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/setup-memory.sh",
+            "once": true
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/scripts/create-plugin-marker.sh",
+            "once": true
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Fixes two `/doctor` errors in the mem8 plugin, both surfacing in current Claude Code builds. The second was masked by the first until it was fixed.

## Commit 1 — invalid `PostInstall` event → `SessionStart` + `once:true`

`hooks/hooks.json` declared its hooks under `PostInstall`, which is not a valid hook event key in current CC, so the whole file failed Zod validation. Two problems:

1. **Invalid event name.** The intent (run setup scripts once when the plugin is first active) maps to **`SessionStart` with `"once": true`**. `Setup` exists but only fires under `--init-only`/`--init`/`--maintenance`, so it wouldn't run for normal users.
2. **Wrong schema.** Events must map to an array of *matcher objects* (`[{ hooks: [...] }]`), not directly to `{type, command}` objects.

`setup-memory.sh` is idempotent (early-exits when `memory/` exists), so `SessionStart once:true` is safe. `${CLAUDE_PLUGIN_ROOT}` is now quoted per the docs.

## Commit 2 — drop redundant `hooks` key from `plugin.json`

Once commit 1 made the hooks file load, CC reported a **duplicate hooks file**: the standard `hooks/hooks.json` is auto-loaded, and `plugin.json` *also* declared `"hooks": "./hooks/hooks.json"` pointing at the same file. Per the error, `manifest.hooks` should only reference *additional* hook files — there are none, so the key is removed.

## Verification

- Both JSON files validate.
- Same changes applied to the local plugin cache (`foundry/mem8/3.1.0`) clear both `/doctor` errors, and the `SessionStart` hooks were observed firing on session resume (`✓ Memory directory already exists`, `✓ Plugin marker created`).

Refs: https://code.claude.com/docs/en/plugins-reference.md (Hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)